### PR TITLE
Add basic project explorer layout

### DIFF
--- a/QS_Takeoff.UI/MainWindow.xaml
+++ b/QS_Takeoff.UI/MainWindow.xaml
@@ -1,18 +1,34 @@
-﻿<Window x:Class="QS_Takeoff.UI.MainWindow"
+<Window x:Class="QS_Takeoff.UI.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:QS_Takeoff.UI"
+        xmlns:views="clr-namespace:QS_Takeoff.UI.Views"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="9*"/>
-            <RowDefinition Height="1*"/>
-        </Grid.RowDefinitions>
-        <Label Content="Hello .NET Core!" HorizontalAlignment="Center" VerticalAlignment="Center"
-               FontSize="40"/>
-        <Button Content="Exit" Grid.Row="1" FontSize="20" Click="ButtonExit_Click"/>
-    </Grid>
+        Title="QS Takeoff" Height="600" Width="1000">
+    <DockPanel>
+        <TabControl DockPanel.Dock="Top">
+            <TabItem Header="Drawing" />
+            <TabItem Header="Revisions" />
+            <TabItem Header="Notes" />
+            <TabItem Header="Subcontracts" />
+            <TabItem Header="Batches" />
+            <TabItem Header="Dimensions" />
+            <TabItem Header="BIDs" />
+            <TabItem Header="Layers" />
+        </TabControl>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="250" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <views:ProjectExplorer Grid.Column="0" />
+
+            <Border Grid.Column="1" Margin="5" BorderBrush="Gray" BorderThickness="1">
+                <TextBlock Text="Drawing area" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
+        </Grid>
+    </DockPanel>
 </Window>

--- a/QS_Takeoff.UI/MainWindow.xaml.cs
+++ b/QS_Takeoff.UI/MainWindow.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace QS_Takeoff.UI
 {
@@ -23,11 +10,6 @@ namespace QS_Takeoff.UI
         public MainWindow()
         {
             InitializeComponent();
-        }
-
-        private void ButtonExit_Click(object sender, RoutedEventArgs e)
-        {
-            Application.Current.Shutdown();
         }
     }
 }

--- a/QS_Takeoff.UI/Views/ProjectExplorer.xaml
+++ b/QS_Takeoff.UI/Views/ProjectExplorer.xaml
@@ -1,4 +1,22 @@
-<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<UserControl x:Class="QS_Takeoff.UI.Views.ProjectExplorer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid />
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Drawings" FontWeight="Bold" Margin="5" />
+
+        <TextBox x:Name="FilterBox" Grid.Row="1" Margin="5" Text="Filter" Foreground="Gray"
+                 GotFocus="FilterBox_GotFocus" LostFocus="FilterBox_LostFocus" />
+
+        <ListBox Grid.Row="2" Margin="5">
+            <ListBoxItem Content="A-101 - Floor Plan" />
+            <ListBoxItem Content="A-201 - Sections" />
+            <ListBoxItem Content="S-001 - General Notes" />
+        </ListBox>
+    </Grid>
 </UserControl>

--- a/QS_Takeoff.UI/Views/ProjectExplorer.xaml.cs
+++ b/QS_Takeoff.UI/Views/ProjectExplorer.xaml.cs
@@ -1,0 +1,32 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace QS_Takeoff.UI.Views
+{
+    public partial class ProjectExplorer : UserControl
+    {
+        public ProjectExplorer()
+        {
+            InitializeComponent();
+        }
+
+        private void FilterBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            if (FilterBox.Text == "Filter")
+            {
+                FilterBox.Text = string.Empty;
+                FilterBox.Foreground = Brushes.Black;
+            }
+        }
+
+        private void FilterBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(FilterBox.Text))
+            {
+                FilterBox.Text = "Filter";
+                FilterBox.Foreground = Brushes.Gray;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tabbed navigation and project explorer panel
- stub drawing area placeholder

## Testing
- `dotnet test QS_TakeoffApp.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec86d94b48326bba3478a1afe1e6f