### PR TITLE
Add dimension group properties window

### DIFF
--- a/QS_Takeoff.UI/MainWindow.xaml
+++ b/QS_Takeoff.UI/MainWindow.xaml
@@ -13,7 +13,9 @@
             <TabItem Header="Notes" />
             <TabItem Header="Subcontracts" />
             <TabItem Header="Batches" />
-            <TabItem Header="Dimensions" />
+            <TabItem Header="Dimensions">
+                <Button Content="Add Dimension Group" Margin="10" Click="OpenDimensionGroupProperties_Click"/>
+            </TabItem>
             <TabItem Header="BIDs" />
             <TabItem Header="Layers" />
         </TabControl>

--- a/QS_Takeoff.UI/MainWindow.xaml.cs
+++ b/QS_Takeoff.UI/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using QS_Takeoff.UI.Views;
 
 namespace QS_Takeoff.UI
 {
@@ -10,6 +11,12 @@ namespace QS_Takeoff.UI
         public MainWindow()
         {
             InitializeComponent();
+        }
+
+        private void OpenDimensionGroupProperties_Click(object sender, RoutedEventArgs e)
+        {
+            var window = new DimensionGroupProperties();
+            window.ShowDialog();
         }
     }
 }

--- a/QS_Takeoff.UI/Models/DimensionGroupPropertiesModel.cs
+++ b/QS_Takeoff.UI/Models/DimensionGroupPropertiesModel.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace QS_Takeoff.UI.Models
+{
+    public class DimensionGroupPropertiesModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Folder { get; set; } = string.Empty;
+        public MeasurementType MeasurementType { get; set; } = MeasurementType.Area;
+        public MeasurementType DefaultDisplay { get; set; } = MeasurementType.Area;
+        public double DefaultMultiplier { get; set; } = 1.0;
+        public double DefaultWidth { get; set; } = 0.0;
+        public double DefaultHeight { get; set; } = 0.0;
+        public double DefaultDepth { get; set; } = 0.0;
+        public bool AddToGfa { get; set; } = false;
+        public string PositiveColor { get; set; } = "User Defined";
+        public string PositiveStyle { get; set; } = "Solid";
+        public string NegativeColor { get; set; } = "Red";
+        public string NegativeStyle { get; set; } = "Solid";
+        public string WeightUom { get; set; } = string.Empty;
+    }
+}

--- a/QS_Takeoff.UI/Models/MeasurementType.cs
+++ b/QS_Takeoff.UI/Models/MeasurementType.cs
@@ -1,0 +1,12 @@
+namespace QS_Takeoff.UI.Models
+{
+    public enum MeasurementType
+    {
+        Count,
+        Length,
+        Area,
+        WallArea,
+        Volume,
+        Weight
+    }
+}

--- a/QS_Takeoff.UI/Views/DimensionGroupProperties.xaml
+++ b/QS_Takeoff.UI/Views/DimensionGroupProperties.xaml
@@ -1,0 +1,90 @@
+<Window x:Class="QS_Takeoff.UI.Views.DimensionGroupProperties"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        mc:Ignorable="d"
+        Title="Dimension Group Properties" Height="450" Width="500">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- Name -->
+        <TextBlock Grid.Row="0" Text="Name:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Name="NameTextBox" Margin="0,0,0,5"/>
+
+        <!-- Folder -->
+        <TextBlock Grid.Row="1" Text="Folder:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Name="FolderTextBox" Margin="0,0,0,5"/>
+
+        <!-- Measurement Type -->
+        <TextBlock Grid.Row="2" Text="Measurement Type:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <ComboBox Grid.Row="2" Grid.Column="1" Name="MeasurementTypeCombo" Margin="0,0,0,5"/>
+
+        <!-- Default Display -->
+        <TextBlock Grid.Row="3" Text="Default Display:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <ComboBox Grid.Row="3" Grid.Column="1" Name="DefaultDisplayCombo" Margin="0,0,0,5"/>
+
+        <!-- Default Multiplier -->
+        <TextBlock Grid.Row="4" Text="Default Multiplier:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="4" Grid.Column="1" Name="MultiplierTextBox" Margin="0,0,0,5" Text="1.000000"/>
+
+        <!-- Default Width -->
+        <TextBlock Grid.Row="5" Text="Default Width:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="5" Grid.Column="1" Name="WidthTextBox" Margin="0,0,0,5" Text="0.0000"/>
+        <TextBlock Grid.Row="5" Grid.Column="2" Text="m" Margin="5,0" VerticalAlignment="Center"/>
+
+        <!-- Default Height -->
+        <TextBlock Grid.Row="6" Text="Default Height:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="6" Grid.Column="1" Name="HeightTextBox" Margin="0,0,0,5" Text="0.0000"/>
+        <TextBlock Grid.Row="6" Grid.Column="2" Text="m" Margin="5,0" VerticalAlignment="Center"/>
+
+        <!-- Default Depth -->
+        <TextBlock Grid.Row="7" Text="Default Depth:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="7" Grid.Column="1" Name="DepthTextBox" Margin="0,0,0,5" Text="0.0000"/>
+        <TextBlock Grid.Row="7" Grid.Column="2" Text="m" Margin="5,0" VerticalAlignment="Center"/>
+
+        <!-- Add to GFA -->
+        <TextBlock Grid.Row="8" Text="Add To GFA:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <CheckBox Grid.Row="8" Grid.Column="1" Name="AddToGfaCheck" Margin="0,0,0,5"/>
+
+        <!-- Positive Dimensions -->
+        <TextBlock Grid.Row="9" Text="Positive Dimensions:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <ComboBox Grid.Row="9" Grid.Column="1" Name="PositiveColorCombo" Margin="0,0,5,5" Width="100"/>
+        <ComboBox Grid.Row="9" Grid.Column="3" Name="PositiveStyleCombo" Margin="0,0,0,5" Width="100"/>
+
+        <!-- Negative Dimensions -->
+        <TextBlock Grid.Row="10" Text="Negative Dimensions:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <ComboBox Grid.Row="10" Grid.Column="1" Name="NegativeColorCombo" Margin="0,0,5,5" Width="100"/>
+        <ComboBox Grid.Row="10" Grid.Column="3" Name="NegativeStyleCombo" Margin="0,0,0,5" Width="100"/>
+
+        <!-- Weight UOM -->
+        <TextBlock Grid.Row="11" Text="Weight UOM:" Margin="0,0,5,5" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="11" Grid.Column="1" Name="WeightUomTextBox" Margin="0,0,0,5"/>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="12" Grid.ColumnSpan="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Name="InsertButton" Content="Insert" Width="75" Margin="0,0,5,0" Click="Insert_Click"/>
+            <Button Name="CancelButton" Content="Cancel" Width="75" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QS_Takeoff.UI/Views/DimensionGroupProperties.xaml.cs
+++ b/QS_Takeoff.UI/Views/DimensionGroupProperties.xaml.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Windows;
+using QS_Takeoff.UI.Models;
+
+namespace QS_Takeoff.UI.Views
+{
+    public partial class DimensionGroupProperties : Window
+    {
+        public DimensionGroupPropertiesModel Properties { get; } = new DimensionGroupPropertiesModel();
+
+        public DimensionGroupProperties()
+        {
+            InitializeComponent();
+
+            MeasurementTypeCombo.ItemsSource = Enum.GetValues(typeof(MeasurementType));
+            DefaultDisplayCombo.ItemsSource = Enum.GetValues(typeof(MeasurementType));
+
+            var colors = new[] { "User Defined", "Red", "Blue", "Green" };
+            PositiveColorCombo.ItemsSource = colors;
+            NegativeColorCombo.ItemsSource = colors;
+
+            var styles = new[] { "Solid", "Dashed", "Dotted" };
+            PositiveStyleCombo.ItemsSource = styles;
+            NegativeStyleCombo.ItemsSource = styles;
+        }
+
+        private void Insert_Click(object sender, RoutedEventArgs e)
+        {
+            Properties.Name = NameTextBox.Text;
+            Properties.Folder = FolderTextBox.Text;
+            if (MeasurementTypeCombo.SelectedItem is MeasurementType mt)
+                Properties.MeasurementType = mt;
+            if (DefaultDisplayCombo.SelectedItem is MeasurementType dd)
+                Properties.DefaultDisplay = dd;
+            if (double.TryParse(MultiplierTextBox.Text, out var mult))
+                Properties.DefaultMultiplier = mult;
+            if (double.TryParse(WidthTextBox.Text, out var width))
+                Properties.DefaultWidth = width;
+            if (double.TryParse(HeightTextBox.Text, out var height))
+                Properties.DefaultHeight = height;
+            if (double.TryParse(DepthTextBox.Text, out var depth))
+                Properties.DefaultDepth = depth;
+            Properties.AddToGfa = AddToGfaCheck.IsChecked == true;
+            Properties.PositiveColor = PositiveColorCombo.SelectedItem?.ToString() ?? "User Defined";
+            Properties.PositiveStyle = PositiveStyleCombo.SelectedItem?.ToString() ?? "Solid";
+            Properties.NegativeColor = NegativeColorCombo.SelectedItem?.ToString() ?? "Red";
+            Properties.NegativeStyle = NegativeStyleCombo.SelectedItem?.ToString() ?? "Solid";
+            Properties.WeightUom = WeightUomTextBox.Text;
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MeasurementType enum and DimensionGroupPropertiesModel
- create DimensionGroupProperties window with fields for measurement settings
- hook window to Dimensions tab in MainWindow

## Testing
- `dotnet test` *(fails to resolve Microsoft.NET.Sdk.WindowsDesktop but runs and passes existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aeca0d8cb083269ba27569d2ba41aa